### PR TITLE
Provide an overload of to_json(io), so attempts of writing to directly IO will not fail

### DIFF
--- a/spec/json_on_steroids_spec.cr
+++ b/spec/json_on_steroids_spec.cr
@@ -1,0 +1,16 @@
+module JsonOnSteriodsSpec
+  describe JSON::OnSteroids do
+    describe "#to_json" do
+      it "should support returning a String" do
+        (JSON::OnSteroids.new a: 1, b: 2).to_json.should eq %<{"a":1,"b":2}>
+      end
+
+      it "should support writing to IO" do
+        output = String.build do |str|
+          (JSON::OnSteroids.new a: 1, b: 2).to_json(str)
+        end
+        output.should eq %<{"a":1,"b":2}>
+      end
+    end
+  end
+end

--- a/src/json_on_steroids.cr
+++ b/src/json_on_steroids.cr
@@ -198,6 +198,10 @@ class JSON::OnSteroids
     to_s
   end
 
+  def to_json(io : IO) : Nil
+    to_s(io)
+  end
+
   def inspect(io)
     io << "JSON::OnSteroids(dirty: #{dirty?.inspect})>" unless @parent
 


### PR DESCRIPTION
Matches the definition of
https://crystal-lang.org/api/1.15.1/Object.html#to_json%28io%3AIO%29%3ANil-instance-method